### PR TITLE
README: Fix broken code block formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ and transports.
 ```python
 from agentmail import AgentMail
 import httpx
-client = AgentMail(..., httpx_client=httpx.Client(proxies="http://my.test.proxy.example.com", transport=httpx.HTTPTransport(local_address="0.0.0.0"), ))```
+client = AgentMail(..., httpx_client=httpx.Client(proxies="http://my.test.proxy.example.com", transport=httpx.HTTPTransport(local_address="0.0.0.0"), ))
+```
 
 ## Contributing
 


### PR DESCRIPTION
This PR fixes a broken code block in the README by adding missing closing backticks to the httpx client configuration example.

As noted in the contributing guidelines: 'contributions to the README are always very welcome!' - this change only touches the README documentation and does not modify any generated code.