### PR TITLE
feat: add nix support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -36,16 +36,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769789167,
-        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
+        "lastModified": 1769900590,
+        "narHash": "sha256-I7Lmgj3owOTBGuauy9FL6qdpeK2umDoe07lM4V+PnyA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
+        "rev": "41e216c0ca66c83b12ab7a98cc326b5db01db646",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769789167,
+        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,8 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    flake-compat.url = "github:edolstra/flake-compat";
+    flake-compat.flake = false;
   };
 
   outputs = { self, nixpkgs, flake-utils }:

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     flake-compat.flake = false;
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, flake-compat, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,85 @@
+{
+  description = "agentmail - Python SDK";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        python = pkgs.python3;
+
+        agentmail = python.pkgs.buildPythonPackage {
+          pname = "agentmail";
+          version = "0.2.10";
+          format = "pyproject";
+          src = ./.;
+
+          nativeBuildInputs = [
+            python.pkgs.poetry-core
+          ];
+
+          propagatedBuildInputs = with python.pkgs; [
+            httpx
+            pydantic
+            pydantic-core
+            typing-extensions
+            websockets
+          ];
+
+          pythonImportsCheck = [ "agentmail" ];
+
+          # Tests require network access / API keys
+          doCheck = false;
+        };
+      in
+      {
+        packages.default = agentmail;
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            (python.withPackages (ps: [
+              agentmail
+              ps.pytest
+              ps.pytest-asyncio
+              ps.pytest-xdist
+              ps.python-dateutil
+              ps.mypy
+              ps.ruff
+            ]))
+          ];
+        };
+      }
+    ) // {
+      overlays.default = final: prev: {
+        pythonPackagesExtensions = (prev.pythonPackagesExtensions or []) ++ [
+          (python-final: python-prev: {
+            agentmail = python-final.buildPythonPackage {
+              pname = "agentmail";
+              version = "0.2.10";
+              format = "pyproject";
+              src = self;
+
+              nativeBuildInputs = [
+                python-final.poetry-core
+              ];
+
+              propagatedBuildInputs = with python-final; [
+                httpx
+                pydantic
+                pydantic-core
+                typing-extensions
+                websockets
+              ];
+
+              pythonImportsCheck = [ "agentmail" ];
+              doCheck = false;
+            };
+          })
+        ];
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "agentmail - Python SDK";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
     flake-compat.url = "github:edolstra/flake-compat";
     flake-compat.flake = false;


### PR DESCRIPTION
Refer to https://github.com/agentmail-to/agentmail-python/issues/8

## Summary
- Add `flake.nix` with `packages.default`, `devShells.default`, and `overlays.default` for Nix-based builds
- Add `default.nix` via `flake-compat` for legacy `nix-env` installation support
- Pin to `nixos-25.11` stable channel for production use

## Acceptance Criteria
- `nix build` completes successfully
- `nix develop --command python -c "import agentmail"` works
- `nix-env -if .` installs the package (legacy support)
- `nix flake check` passes
- Dev shell includes `pytest`, `mypy`, and `ruff`
- Pinned to `nixos-25.11` stable channel


### Usage

```bash
# Build the package
nix build

# Enter dev shell (includes pytest, mypy, ruff)
nix develop

# Install via flake
nix profile install github:agentmail-to/agentmail-python
```