### PR TITLE
docs: add Quick Start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # Agentmail Python Library
 
+
+## Quick Start
+
+Install with:
+```bash
+pip install agentmail-python
+```
+
+Or clone and run:
+```bash
+git clone https://github.com/agentmail-to/agentmail-python.git
+cd agentmail-python
+python setup.py install
+```
+
+
 [![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com?utm_source=github&utm_medium=github&utm_campaign=readme&utm_source=https%3A%2F%2Fgithub.com%2Fagentmail-to%2Fagentmail-python)
 [![pypi](https://img.shields.io/pypi/v/agentmail)](https://pypi.python.org/pypi/agentmail)
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 
 Install with:
 ```bash
-pip install agentmail-python
+pip install agentmail
 ```
 
 Or clone and run:
 ```bash
 git clone https://github.com/agentmail-to/agentmail-python.git
 cd agentmail-python
-python setup.py install
+pip install -e .
+# or: pip install agentmail
 ```
 
 


### PR DESCRIPTION
## Summary
Adds a Quick Start section to the README with basic installation and usage instructions.

## Changes
- Added Quick Start section with installation commands
- Fixed package name: `agentmail-python` → `agentmail` (correct PyPI package name)
- Fixed install method: `python setup.py install` → `pip install -e .`

## PR Feedback Response
- Changed `pip install agentmail-python` to `pip install agentmail` (correct package name on PyPI)
- Changed `python setup.py install` to `pip install -e .` (proper Python package installation)

Thanks to the reviewer for catching these issues!


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Quick Start guide to the README with correct install steps for the `agentmail` package. Clarifies install via PyPI (`pip install agentmail`) or local editable install (`pip install -e .`).

<sup>Written for commit a14aef4ff1ade20f99c9ad941f0193525edde74c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/agentmail-to/agentmail-python/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

