### PR TITLE
Add MIT LICENSE

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -2,5 +2,3 @@
 
 src/agentmail/core/query_encoder.py
 tests/utils/test_query_encoding.py
-
-LICENSE

--- a/.fernignore
+++ b/.fernignore
@@ -2,3 +2,5 @@
 
 src/agentmail/core/query_encoder.py
 tests/utils/test_query_encoding.py
+
+LICENSE

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 AgentMail
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This repository is publicly distributed but carried no license file. Without one the default is *all rights reserved*, which leaves users installing the published package with no grant to the code.

Adds the MIT text already used verbatim in `agentextract`, same copyright holder and year.

`LICENSE` is also registered in `.fernignore` — without it the next SDK regeneration would delete the file again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)